### PR TITLE
Corrected possible mistake

### DIFF
--- a/LocalPeerDiscovery.cs
+++ b/LocalPeerDiscovery.cs
@@ -98,8 +98,8 @@ namespace System.Net.Torrent
 		{
 			var endPoint = new IPEndPoint(address, port);
 
-			udpReaderSocket.ExclusiveAddressUse = false;
-			udpReaderSocket.SetSocketOption(SocketOptionLevel.Socket,
+			udpSenderSocket.ExclusiveAddressUse = false;
+			udpSenderSocket.SetSocketOption(SocketOptionLevel.Socket,
 				SocketOptionName.ReuseAddress,
 				true);
 			udpSenderSocket.SetSocketOption(SocketOptionLevel.IP, 


### PR DESCRIPTION
This might be a fix for the
`Bind has already been called for this socket` error I get whenever I call `Open();` on an instance of `LocalPeerDiscovery`.
Unfortunately, I can't test it, because of https://github.com/bizzehdee/System.Net.Torrent/issues/2.
